### PR TITLE
Revert Back To User Email Instead of User ID

### DIFF
--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -144,7 +144,7 @@ module SpreeAvatax::SalesShared
     def gettax_params(order, doc_type)
       {
         doccode:       order.number,
-        customercode:  order.user_id,
+        customercode:  customer_code(order),
         companycode:   SpreeAvatax::Config.company_code,
 
         doctype: doc_type,
@@ -171,6 +171,10 @@ module SpreeAvatax::SalesShared
 
         lines: gettax_lines_params(order),
       }
+    end
+
+    def customer_code(order)
+      order.user ? order.user_id : REXML::Text.normalize(order.email)[0, 50]
     end
 
     def gettax_lines_params(order)


### PR DESCRIPTION
#### What does this PR do?
Previously we had made a change to rely on the user id for avalara's
customer code value. However, with the change to guest checkout we may
not have a user id for all customers. So this change will revert this
code back to use the email. I am also adding a limit to make sure this
value doesn't exceed 50 characters since that is the max allowed value
by avalara. This should allow us to calculate tax's for all of orders
including guest orders.