### PR TITLE
Allow for guest orders without emails yet for taxes

### DIFF
--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -174,7 +174,13 @@ module SpreeAvatax::SalesShared
     end
 
     def customer_code(order)
-      order.user ? order.user_id : REXML::Text.normalize(order.email)[0, 50]
+      if (order.user)
+        order.user_id
+      elsif order.email
+        REXML::Text.normalize(order.email)[0, 50]
+      else
+        "guest-#{order.number}"
+      end
     end
 
     def gettax_lines_params(order)


### PR DESCRIPTION
With the addition of apple pay and stripe payment request button we
would like for our customers to have their taxes calculated before we
add an email to the user. This should allow us to do that by creating a
last option for when the user or email does not exist on the order and
we need a customer code to calculate taxes.