### PR TITLE
Allow developers to adjust existing sales invoices

### DIFF
--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -25,6 +25,19 @@ module SpreeAvatax::SalesShared
       response
     end
 
+    def adjust_tax(order, adjustment_reason, doc_type)
+      params = gettax_params(order, doc_type)
+      params[:adjustmentreason] = adjustment_reason
+
+      logger.info "[avatax] adjusttax order=#{order.id} doc_type=#{doc_type}"
+      logger.debug { "[avatax] params: #{params.to_json}" }
+
+      response = SpreeAvatax::Shared.adjust_tax(params)
+      SpreeAvatax::Shared.require_success!(response)
+
+      response
+    end
+
     def update_taxes(order, tax_line_data)
       reset_tax_attributes(order)
 

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -28,6 +28,7 @@ module SpreeAvatax::SalesShared
     def adjust_tax(order, adjustment_reason, doc_type)
       params = gettax_params(order, doc_type)
       params[:adjustmentreason] = adjustment_reason
+      params[:commit] = true
 
       logger.info "[avatax] adjusttax order=#{order.id} doc_type=#{doc_type}"
       logger.debug { "[avatax] params: #{params.to_json}" }

--- a/app/models/spree_avatax/shared.rb
+++ b/app/models/spree_avatax/shared.rb
@@ -32,6 +32,10 @@ module SpreeAvatax::Shared
       call_tax_svc_with_timeout(:gettax, params)
     end
 
+    def adjust_tax(params)
+      call_tax_svc_with_timeout(:adjusttax, params)
+    end
+
     def post_tax(params)
       call_tax_svc_with_timeout(:posttax, params)
     end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll add the SalesInvoice.adjust method which will allow developers to update an already committed transaction in Avatax by using the `adjustTax` endpoint.

#### Relevant links
https://developer.avalara.com/api-reference/avatax/soap/methods/adjustTax/