### PR TITLE
Allow guest short ship and returns

### DIFF
--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -132,7 +132,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
       {
         doccode:       reimbursement.number,
         referencecode: reimbursement.order.number,
-        customercode:  reimbursement.order.user_id,
+        customercode:  customer_code(reimbursement.order),
         companycode:   SpreeAvatax::Config.company_code,
 
         doctype: DOC_TYPE,
@@ -157,6 +157,16 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
 
         lines: get_tax_line_params(reimbursement),
       }
+    end
+
+    def customer_code(order)
+      if (order.user)
+        order.user_id
+      elsif order.email
+        REXML::Text.normalize(order.email)[0, 50]
+      else
+        "guest-#{order.number}"
+      end
     end
 
     def get_tax_line_params(reimbursement)

--- a/app/models/spree_avatax/short_ship_return_invoice.rb
+++ b/app/models/spree_avatax/short_ship_return_invoice.rb
@@ -72,7 +72,7 @@ class SpreeAvatax::ShortShipReturnInvoice < ActiveRecord::Base
       {
         doccode:       "#{order.number}-short-#{Time.now.to_f}",
         referencecode: order.number,
-        customercode:  order.user_id,
+        customercode:  customer_code(order),
         companycode:   SpreeAvatax::Config.company_code,
 
         doctype: DOC_TYPE,
@@ -92,6 +92,16 @@ class SpreeAvatax::ShortShipReturnInvoice < ActiveRecord::Base
 
         lines: lines,
       }
+    end
+
+    def customer_code(order)
+      if (order.user)
+        order.user_id
+      elsif order.email
+        REXML::Text.normalize(order.email)[0, 50]
+      else
+        "guest-#{order.number}"
+      end
     end
 
     def gettax_line_params(unit_cancels:, taxed_at:)


### PR DESCRIPTION
#### What does this PR do?
Our short ship and returns tax invoices were still only using `user_id`
for the `customercode`. With this change we will use the same logic to
default to the email for guest orders, when the user_id is nil.

#### Relevant Tickets
[Finishes #164612300]